### PR TITLE
Microbenchmark Path creation

### DIFF
--- a/changelog/@unreleased/pr-20.v2.yml
+++ b/changelog/@unreleased/pr-20.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Microbenchmark Path creation
+  links:
+  - https://github.com/palantir/syntactic-paths/pull/20

--- a/syntactic-paths/build.gradle
+++ b/syntactic-paths/build.gradle
@@ -23,6 +23,9 @@ jmh {
     // [cl, comp, gc, jfr, stack, perf, perfnorm, perfasm, xperf, xperfasm, hs_cl, hs_comp, hs_gc, hs_rt, hs_thr]
     //profilers = ['jfr']
     //jvmArgsPrepend = ['-XX:+UnlockDiagnosticVMOptions', '-XX:+DebugNonSafepoints']
+    humanOutputFile = project.file("${resultsDir(project)}/results.txt")
+    resultsFile = project.file("${resultsDir(project)}/results.json")
+    resultFormat = 'JSON'
 }
 
 tasks.jmhCompileGeneratedClasses {
@@ -30,3 +33,11 @@ tasks.jmhCompileGeneratedClasses {
     options.errorprone.enabled = true
 }
 
+
+def resultsDir(Project project) {
+    String circleArtifactsDir = System.getenv("CIRCLE_ARTIFACTS");
+    if (circleArtifactsDir == null) {
+        return project.getBuildDir().toString() + "/results/jmh";
+    }
+    return circleArtifactsDir + "/jmh/" + project.getName();
+}

--- a/syntactic-paths/build.gradle
+++ b/syntactic-paths/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.palantir.external-publish-jar'
 apply plugin: 'com.palantir.revapi'
+apply plugin: 'me.champeau.jmh'
 
 dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
@@ -12,4 +13,20 @@ dependencies {
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
+
+    jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
+    jmh 'com.fasterxml.jackson.core:jackson-annotations'
 }
+
+jmh {
+    // Use profilers to collect additional data. Supported profilers:
+    // [cl, comp, gc, jfr, stack, perf, perfnorm, perfasm, xperf, xperfasm, hs_cl, hs_comp, hs_gc, hs_rt, hs_thr]
+    //profilers = ['jfr']
+    //jvmArgsPrepend = ['-XX:+UnlockDiagnosticVMOptions', '-XX:+DebugNonSafepoints']
+}
+
+tasks.jmhCompileGeneratedClasses {
+    options.annotationProcessorPath = configurations.errorprone
+    options.errorprone.enabled = true
+}
+

--- a/syntactic-paths/src/jmh/java/com/palantir/util/syntacticpath/PathsBenchmark.java
+++ b/syntactic-paths/src/jmh/java/com/palantir/util/syntacticpath/PathsBenchmark.java
@@ -1,0 +1,65 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.util.syntacticpath;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(Threads.MAX)
+@State(Scope.Benchmark)
+@SuppressWarnings({"designforextension", "NullAway"})
+public class PathsBenchmark {
+
+    @Benchmark
+    public Path stringOne() {
+        return Paths.get("/test");
+    }
+
+    @Benchmark
+    public Path stringThree() {
+        return Paths.get("/test/foo/bar");
+    }
+
+    @Benchmark
+    public Path varArgsOne() {
+        return Paths.get("/test", "");
+    }
+
+    @Benchmark
+    public Path varArgsTwo() {
+        return Paths.get("/test", "foo");
+    }
+
+    @Benchmark
+    public Path varArgsThree() {
+        return Paths.get("/test", "foo", "bar");
+    }
+}

--- a/versions.lock
+++ b/versions.lock
@@ -1,5 +1,5 @@
 # Run ./gradlew --write-locks to regenerate this file
-com.fasterxml.jackson.core:jackson-annotations:2.13.3 (1 constraints: 89123821)
+com.fasterxml.jackson.core:jackson-annotations:2.13.3 (2 constraints: c3178471)
 com.google.code.findbugs:jsr305:3.0.2 (1 constraints: 170aecb4)
 com.google.errorprone:error_prone_annotations:2.11.0 (2 constraints: 751be887)
 com.google.guava:failureaccess:1.0.1 (1 constraints: 140ae1b4)

--- a/versions.props
+++ b/versions.props
@@ -1,7 +1,8 @@
-com.fasterxml.jackson.core:jackson-databind = 2.13.3
+com.fasterxml.jackson.*:* = 2.13.3
 com.google.guava:guava = 31.1-jre
 com.palantir.safe-logging:* = 3.0.0
 org.assertj:assertj-core = 3.23.1
 org.junit.jupiter:* = 5.9.0
 org.mockito:* = 4.8.0
+org.openjdk.jmh:* = 1.35
 org.slf4j:* = 1.7.36


### PR DESCRIPTION
## Before this PR
There were no microbenchmarks for `Path` creation


## After this PR
CircleCI produces JMH benchmark artifacts, e.g.:

- [~/artifacts/jmh/syntactic-paths/results.json](https://output.circle-artifacts.com/output/job/5678fd96-56e0-4c4d-9fe7-5a5fa8ab20ce/artifacts/0/~/artifacts/jmh/syntactic-paths/results.json)
- [~/artifacts/jmh/syntactic-paths/results.txt](https://output.circle-artifacts.com/output/job/5678fd96-56e0-4c4d-9fe7-5a5fa8ab20ce/artifacts/0/~/artifacts/jmh/syntactic-paths/results.txt)


==COMMIT_MSG==
Microbenchmark Path creation
==COMMIT_MSG==

## Possible downsides?
CI builds are slightly longer due to JMH; however, this project is relatively tiny but performance sensitive so probably worth the compute & time

